### PR TITLE
cambios de logica sesion 8 de febrero 2025

### DIFF
--- a/worlds/dkc2/Rules.py
+++ b/worlds/dkc2/Rules.py
@@ -706,7 +706,8 @@ class DKC2StrictRules(DKC2Rules):
                     self.has_controllable_barrels(state),
 
             LocationName.fiery_furnace_clear:
-                lambda state: self.has_controllable_barrels(state) and self.can_cartwheel(state),
+                lambda state: self.has_controllable_barrels(state) and self.can_cartwheel(state)
+                    and self.can_team_attack(state),
             LocationName.fiery_furnace_kong:
                 lambda state: self.has_controllable_barrels(state) and self.can_cartwheel(state)
                     and self.can_team_attack(state),
@@ -715,15 +716,15 @@ class DKC2StrictRules(DKC2Rules):
                     and self.can_team_attack(state),
 
             LocationName.animal_antics_clear:
-                lambda state: self.has_rambi(state) and self.has_enguarde(state) and self.has_squitter(state) and 
+                lambda state: self.has_both_kongs(state) and self.has_rambi(state) and self.has_enguarde(state) and self.has_squitter(state) and 
                     self.has_squawks(state) and self.has_rattly(state) and self.can_swim(state) and 
                     self.has_kannons(state),
             LocationName.animal_antics_kong:
-                lambda state: self.has_rambi(state) and self.has_enguarde(state) and self.has_squitter(state) and 
+                lambda state: self.has_both_kongs(state) and self.has_rambi(state) and self.has_enguarde(state) and self.has_squitter(state) and 
                     self.has_squawks(state) and self.has_rattly(state) and self.can_swim(state) and 
                     self.has_kannons(state),
             LocationName.animal_antics_dk_coin:
-                lambda state: self.has_rambi(state) and self.has_enguarde(state) and self.has_squitter(state) and 
+                lambda state: self.has_both_kongs(state) and self.has_rambi(state) and self.has_enguarde(state) and self.has_squitter(state) and 
                     self.has_squawks(state) and self.can_swim(state),
 
             LocationName.krocodile_core_clear:

--- a/worlds/dkc2/Rules.py
+++ b/worlds/dkc2/Rules.py
@@ -2736,7 +2736,7 @@ class DKC2LooseRules(DKC2Rules):
             LocationName.web_woods_green_balloon_1:
                 lambda state: self.can_team_attack(state) and self.can_carry(state) and self.has_kannons(state),
             LocationName.web_woods_banana_bunch_1:
-                self.can_cartwheel,
+                lambda state: self.can_team_attack(state) or self.can_cartwheel(state),
             LocationName.web_woods_banana_bunch_2:
                 self.can_carry,
             LocationName.web_woods_banana_bunch_3:

--- a/worlds/dkc2/Rules.py
+++ b/worlds/dkc2/Rules.py
@@ -2325,7 +2325,7 @@ class DKC2LooseRules(DKC2Rules):
                 self.has_squitter,
 
             LocationName.kannons_klaim_banana_bunch_1:
-                lambda state: self.has_kannons(state) and ((self.can_cling(state) and self.can_hover(state)) or self.can_team_attack(state)),
+                lambda state: self.has_kannons(state) or self.can_team_attack(state),
             LocationName.kannons_klaim_banana_coin_1:
                 lambda state: self.has_kannons(state),
             LocationName.kannons_klaim_banana_coin_2:

--- a/worlds/dkc2/Rules.py
+++ b/worlds/dkc2/Rules.py
@@ -538,7 +538,7 @@ class DKC2StrictRules(DKC2Rules):
                 lambda state: self.can_cling(state) and self.has_skull_kart(state),
 
             LocationName.gusty_glade_clear:
-                lambda state: self.can_cling(state) and self.has_kannons(state),
+                lambda state: self.can_cling(state) and self.has_kannons(state) and self.can_cartwheel(state),
             LocationName.gusty_glade_kong:
                 lambda state: self.can_cling(state) and self.has_kannons(state) and self.can_carry(state) and
                     self.can_cartwheel(state),

--- a/worlds/dkc2/Rules.py
+++ b/worlds/dkc2/Rules.py
@@ -1868,9 +1868,9 @@ class DKC2LooseRules(DKC2Rules):
                 self.can_carry,
 
             LocationName.hornet_hole_clear:
-                lambda state: self.can_cling(state) and self.has_squitter(state) and self.can_team_attack(state),
+                self.can_cling,
             LocationName.hornet_hole_kong:
-                lambda state: self.can_cling(state) and self.has_squitter(state) and self.can_team_attack(state),
+                self.can_cling,
             LocationName.hornet_hole_dk_coin:
                 lambda state: self.can_cling(state) and self.has_squitter(state) and self.can_team_attack(state),
             LocationName.hornet_hole_bonus_1:
@@ -2572,8 +2572,7 @@ class DKC2LooseRules(DKC2Rules):
             LocationName.hornet_hole_green_balloon_1:
                 self.can_carry,
             LocationName.hornet_hole_banana_coin_3:
-                lambda state: self.can_team_attack(state) and self.has_squitter(state) and 
-                    self.can_cling(state),
+                self.true,
             LocationName.hornet_hole_banana_bunch_3:
                 lambda state: self.can_team_attack(state) and self.has_squitter(state) and 
                     self.can_cling(state),
@@ -2584,8 +2583,7 @@ class DKC2LooseRules(DKC2Rules):
                 lambda state: self.can_team_attack(state) and self.has_squitter(state) and 
                     self.can_cling(state),
             LocationName.hornet_hole_banana_bunch_5:
-                lambda state: self.can_team_attack(state) and self.has_squitter(state) and 
-                    self.can_cling(state),
+                self.can_team_attack,
             LocationName.hornet_hole_red_balloon_1:
                 lambda state: self.can_team_attack(state) and self.has_squitter(state) and 
                     self.can_cling(state),

--- a/worlds/dkc2/Rules.py
+++ b/worlds/dkc2/Rules.py
@@ -1252,9 +1252,9 @@ class DKC2StrictRules(DKC2Rules):
             LocationName.haunted_hall_banana_coin_1:
                 self.can_cartwheel,
             LocationName.haunted_hall_banana_coin_2:
-                self.has_skull_kart,
+                lambda state: self.can_cling(state) and self.has_skull_kart(state),
             LocationName.haunted_hall_banana_coin_3:
-                self.has_skull_kart,
+                lambda state: self.can_cling(state) and self.has_skull_kart(state),
 
             LocationName.gusty_glade_banana_coin_1:
                 self.can_team_attack,
@@ -2694,9 +2694,15 @@ class DKC2LooseRules(DKC2Rules):
             LocationName.haunted_hall_banana_coin_1:
                 self.can_cartwheel,
             LocationName.haunted_hall_banana_coin_2:
-                self.has_skull_kart,
+                lambda state: self.has_skull_kart(state) and (
+                    self.can_cartwheel(state) or self.can_hover(state) or self.can_cling(state) or 
+                    self.can_team_attack(state)
+                ),
             LocationName.haunted_hall_banana_coin_3:
-                self.has_skull_kart,
+                lambda state: self.has_skull_kart(state) and (
+                    self.can_cartwheel(state) or self.can_hover(state) or self.can_cling(state) or 
+                    self.can_team_attack(state)
+                ),
 
             LocationName.gusty_glade_banana_coin_1:
                 self.can_team_attack,

--- a/worlds/dkc2/Rules.py
+++ b/worlds/dkc2/Rules.py
@@ -1731,9 +1731,9 @@ class DKC2LooseRules(DKC2Rules):
                 self.has_squitter,
 
             LocationName.kannons_klaim_clear:
-                lambda state: self.can_carry(state) and self.has_kannons(state),
+                self.has_kannons,
             LocationName.kannons_klaim_kong:
-                lambda state: self.can_carry(state) and self.has_kannons(state),
+                self.has_kannons,
             LocationName.kannons_klaim_dk_coin:
                 lambda state: self.can_hover(state) or self.can_cartwheel(state),
             LocationName.kannons_klaim_bonus_1:
@@ -1741,9 +1741,9 @@ class DKC2LooseRules(DKC2Rules):
                     self.can_hover(state) or self.can_cartwheel(state)
                 ),
             LocationName.kannons_klaim_bonus_2:
-                lambda state: self.can_carry(state) and self.can_team_attack(state) and self.has_kannons(state),
+                self.has_kannons,
             LocationName.kannons_klaim_bonus_3:
-                lambda state: self.can_carry(state) and self.has_kannons(state),
+                self.has_kannons,
 
             LocationName.lava_lagoon_clear:
                 lambda state: self.can_swim(state) and self.has_clapper(state) and self.has_kannons(state) and 
@@ -2325,7 +2325,7 @@ class DKC2LooseRules(DKC2Rules):
                 self.has_squitter,
 
             LocationName.kannons_klaim_banana_bunch_1:
-                lambda state: self.has_kannons(state) and self.can_cling(state),
+                lambda state: self.has_kannons(state) and ((self.can_cling(state) and self.can_hover(state)) or self.can_team_attack(state)),
             LocationName.kannons_klaim_banana_coin_1:
                 lambda state: self.has_kannons(state),
             LocationName.kannons_klaim_banana_coin_2:

--- a/worlds/dkc2/Rules.py
+++ b/worlds/dkc2/Rules.py
@@ -598,7 +598,7 @@ class DKC2StrictRules(DKC2Rules):
             LocationName.windy_well_dk_coin:
                 lambda state: self.has_kannons(state) and self.can_cling(state) and self.has_both_kongs(state) and self.can_carry(state),
             LocationName.windy_well_bonus_1:
-                self.can_cling,
+                lambda state: self.can_cling(state) and self.can_carry(state),
             LocationName.windy_well_bonus_2:
                 lambda state: self.has_kannons(state) and self.can_cling(state) and self.can_carry(state) and 
                     self.has_squawks(state) and self.has_both_kongs(state),

--- a/worlds/dkc2/Rules.py
+++ b/worlds/dkc2/Rules.py
@@ -2583,7 +2583,7 @@ class DKC2LooseRules(DKC2Rules):
                 lambda state: self.can_team_attack(state) and self.has_squitter(state) and 
                     self.can_cling(state),
             LocationName.hornet_hole_banana_bunch_5:
-                self.can_team_attack,
+                lambda state: self.can_team_attack(state) and self.can_cling(state),
             LocationName.hornet_hole_red_balloon_1:
                 lambda state: self.can_team_attack(state) and self.has_squitter(state) and 
                     self.can_cling(state),


### PR DESCRIPTION
strict:
gusty glade - clear
windy well - bonus 1
fiery furnace - clear
animal antics - clear, dk y kong
haunted hall - coin 1 y 2

loose:
kannon's klaim - clear, kong, bonus 2, bonus 3, bunch 1
hornet hole - clear, kong, coin 3, bunch 5
haunted hall - coin 1 y 2
web woods - bunch 1
