### PR TITLE
mas fixes (lunes 10 feb 2025)

### DIFF
--- a/worlds/dkc2/Names/LocationName.py
+++ b/worlds/dkc2/Names/LocationName.py
@@ -289,10 +289,10 @@ gangplank_galley_banana_bunch_2 = "Gangplank Galley - Banana Bunch #2 (First che
 gangplank_galley_red_balloon_1 = "Gangplank Galley - Red Balloon #1 (Chest before Neek)"
 gangplank_galley_banana_bunch_3 = "Gangplank Galley - Banana Bunch #3 (Hook before O)"
 gangplank_galley_banana_coin_1 = "Gangplank Galley - Banana Coin #1 (Chest before midpoint)"
-gangplank_galley_banana_bunch_4 = "Gangplank Galley - Banana Bunch #4 (Chest before Kruncha trio)"
+gangplank_galley_banana_bunch_4 = "Gangplank Galley - Banana Bunch #4 (Below Kruncha trio)"
 gangplank_galley_banana_coin_2 = "Gangplank Galley - Banana Coin #2 (Below Kruncha trio)"
 gangplank_galley_banana_bunch_5 = "Gangplank Galley - Banana Bunch #5 (Below Kruncha trio)"
-gangplank_galley_banana_bunch_6 = "Gangplank Galley - Banana Bunch #6 (Below Kruncha trio)"
+gangplank_galley_banana_bunch_6 = "Gangplank Galley - Banana Bunch #6 (Chest before Kruncha trio)"
 gangplank_galley_banana_bunch_7 = "Gangplank Galley - Banana Bunch #7 (After G chest)"
 gangplank_galley_red_balloon_2 = "Gangplank Galley - Red Balloon #2 (Chest on barrel between Krunchas)"
 

--- a/worlds/dkc2/Rules.py
+++ b/worlds/dkc2/Rules.py
@@ -3377,7 +3377,7 @@ class DKC2ExpertRules(DKC2Rules):
             LocationName.rickety_race_dk_coin:
                 self.has_skull_kart,
             LocationName.rickety_race_bonus_1:
-                lambda state: self.has_skull_kart and 
+                lambda state: self.has_skull_kart(state) and 
                     self.can_team_attack(state) 
                     and self.can_hover(state),
 

--- a/worlds/dkc2/Rules.py
+++ b/worlds/dkc2/Rules.py
@@ -773,11 +773,17 @@ class DKC2StrictRules(DKC2Rules):
             LocationName.gangplank_galley_banana_coin_1:
                 self.can_carry,
             LocationName.gangplank_galley_banana_bunch_4:
-                lambda state: self.can_cling(state) and self.has_kannons(state),
+                lambda state: self.can_cling(state) and self.has_kannons(state) and (
+                    self.can_hover(state) or self.can_cartwheel(state)
+                ),
             LocationName.gangplank_galley_banana_coin_2:
-                lambda state: self.can_cling(state) and self.has_kannons(state),
+                lambda state: self.can_cling(state) and self.has_kannons(state) and (
+                    self.can_hover(state) or self.can_cartwheel(state)
+                ),
             LocationName.gangplank_galley_banana_bunch_5:
-                lambda state: self.can_cling(state) and self.has_kannons(state),
+                lambda state: self.can_cling(state) and self.has_kannons(state) and (
+                    self.can_hover(state) or self.can_cartwheel(state)
+                ),
             LocationName.gangplank_galley_banana_bunch_6:
                 lambda state: self.can_cling(state) and self.can_carry(state),
             LocationName.gangplank_galley_banana_bunch_7:
@@ -817,7 +823,7 @@ class DKC2StrictRules(DKC2Rules):
             LocationName.topsail_trouble_red_balloon_2:
                 lambda state: self.can_carry(state) and (self.has_rattly(state) or (self.can_team_attack(state) and self.can_cling(state))),
             LocationName.topsail_trouble_banana_bunch_1:
-                lambda state: self.can_climb(state) and self.can_carry and (
+                lambda state: self.can_climb(state) and self.can_carry(state) and (
                     self.can_team_attack(state) or
                     self.has_rattly(state) or 
                     (self.can_cling(state) and self.has_kannons(state))
@@ -841,7 +847,7 @@ class DKC2StrictRules(DKC2Rules):
                     (self.can_cling(state) and self.has_kannons(state))
                 ),
             LocationName.topsail_trouble_banana_coin_4:
-                lambda state: self.can_climb(state) and self.can_carry and (
+                lambda state: self.can_climb(state) and self.can_carry(state) and (
                     self.can_team_attack(state) or
                     self.has_rattly(state) or 
                     (self.can_cling(state) and self.has_kannons(state))
@@ -2269,7 +2275,7 @@ class DKC2LooseRules(DKC2Rules):
                     self.has_rattly(state) or self.can_team_attack(state) or self.can_cling(state)
                 ),
             LocationName.topsail_trouble_banana_bunch_1:
-                lambda state: self.can_carry and (
+                lambda state: self.can_carry(state) and (
                     self.can_team_attack(state) or
                     self.has_rattly(state) or 
                     (self.can_cling(state) and self.has_kannons(state))
@@ -2293,7 +2299,7 @@ class DKC2LooseRules(DKC2Rules):
                     (self.can_cling(state) and self.has_kannons(state))
                 ),
             LocationName.topsail_trouble_banana_coin_4:
-                lambda state: self.can_climb(state) and self.can_carry and (
+                lambda state: self.can_climb(state) and self.can_carry(state) and (
                     self.can_team_attack(state) or
                     self.has_rattly(state) or 
                     (self.can_cling(state) and self.has_kannons(state))


### PR DESCRIPTION
añadidos (state) faltantes en checks de topsail trouble (strict y loose)
añadido (state) faltante en rickety race bonus 1 (expert)

añadida logica faltante para gangplank galley en strict

arreglados nombres intercambiados en gangplank galley (base)

genera bien en las 3 logicas