### PR TITLE
mas fixes (sesion 15 feb 2025)

### DIFF
--- a/worlds/dkc2/Rules.py
+++ b/worlds/dkc2/Rules.py
@@ -3320,21 +3320,25 @@ class DKC2ExpertRules(DKC2Rules):
                 self.can_carry,
 
             LocationName.hornet_hole_clear:
-                self.can_cling,
+                lambda state: self.can_cling(state) or (self.can_team_attack(state) and self.has_squitter(state)),
             LocationName.hornet_hole_kong:
-                self.can_cling,
+                lambda state: self.can_cling(state) or (self.can_team_attack(state) and self.has_squitter(state)),
             LocationName.hornet_hole_dk_coin:
-                lambda state: self.can_cling(state) and 
-                    self.can_team_attack(state) and 
-                    self.has_squitter(state),
+                lambda state: self.has_squitter(state) and (
+                    (self.has_both_kongs(state) and self.can_cling(state)) or self.can_team_attack(state)
+                    ),
             LocationName.hornet_hole_bonus_1:
-                lambda state: self.can_cling(state) and 
-                    self.can_team_attack(state) and 
-                    self.can_carry(state),
+                lambda state: self.can_carry(state) and ((self.can_team_attack(state) and self.can_cling(state)) or (self.has_squitter(state) and (
+                    (self.has_both_kongs(state) and self.can_cling(state)) or self.can_team_attack(state)))
+                ),
             LocationName.hornet_hole_bonus_2:
-                lambda state: self.can_cling(state) and self.can_team_attack(state),
+                lambda state: (self.can_team_attack(state) and self.can_cling(state)) or (self.has_squitter(state) and (
+                    (self.has_both_kongs(state) and self.can_cling(state)) or self.can_team_attack(state))
+                    ),
             LocationName.hornet_hole_bonus_3:
-                lambda state: self.can_team_attack(state) and self.has_squitter(state) and (self.can_cling(state) or self.has_both_kongs(state)),
+                lambda state: self.has_squitter(state) and (
+                    (self.has_both_kongs(state) and self.can_cling(state)) or self.can_team_attack(state)
+                    ),
 
             LocationName.target_terror_clear:
                 lambda state: self.has_kannons(state) and self.has_skull_kart(state),
@@ -3554,7 +3558,7 @@ class DKC2ExpertRules(DKC2Rules):
                     self.can_hover(state) or (self.can_cartwheel(state) or self.has_both_kongs(state)),
                 ),
             LocationName.castle_crush_bonus_1:
-                lambda state: self.has_rambi(state) and self.has_both_kongs(state) and  self.can_carry(state),
+                lambda state: self.has_rambi(state) and (self.has_both_kongs(state) or self.can_team_attack(state)),
             LocationName.castle_crush_bonus_2:
                 lambda state: self.can_carry(state) and self.has_squawks(state) and (
                     self.has_both_kongs(state) or 
@@ -3700,22 +3704,19 @@ class DKC2ExpertRules(DKC2Rules):
                 ),
 
             LocationName.animal_antics_clear:
-                lambda state: self.can_swim(state) and self.has_kannons(state) and
-                    self.has_squitter and self.has_enguarde(state) and (
+                lambda state: self.can_swim(state) and self.has_kannons(state) and self.has_enguarde(state) and (
                         self.has_rambi(state) or (
                             self.can_hover(state) and self.can_team_attack(state)
                         )
                     ),
             LocationName.animal_antics_kong:
-                lambda state: self.can_swim(state) and self.has_kannons(state) and
-                    self.has_squitter and self.has_enguarde(state) and (
+                lambda state: self.can_swim(state) and self.has_kannons(state) and self.has_enguarde(state) and (
                         self.has_rambi(state) or (
                             self.can_hover(state) and self.can_team_attack(state)
                         )
                     ),
             LocationName.animal_antics_dk_coin:
-                lambda state: self.can_swim(state) and self.has_kannons(state) and
-                    self.has_squitter and self.has_enguarde(state) and (
+                lambda state: self.can_swim(state) and self.has_kannons(state) and self.has_enguarde(state) and (
                         self.has_rambi(state) or (
                             self.can_hover(state) and self.can_team_attack(state)
                         )
@@ -4103,11 +4104,17 @@ class DKC2ExpertRules(DKC2Rules):
                 lambda state: self.has_kannons(state) and self.has_squawks(state),
 
             LocationName.hornet_hole_banana_bunch_1:
-                lambda state: self.can_team_attack(state) and self.can_cling(state),
+                lambda state: (self.can_team_attack(state) and self.can_cling(state)) or (self.has_squitter(state) and (
+                    (self.has_both_kongs(state) and self.can_cling(state)) or self.can_team_attack(state))
+                    ),
             LocationName.hornet_hole_banana_coin_1:
-                lambda state: self.can_team_attack(state) and self.can_cling(state),
+                lambda state: (self.can_team_attack(state) and self.can_cling(state)) or (self.has_squitter(state) and (
+                    (self.has_both_kongs(state) and self.can_cling(state)) or self.can_team_attack(state))
+                    ),
             LocationName.hornet_hole_banana_bunch_2:
-                lambda state: self.can_team_attack(state) and self.can_cling(state),
+                lambda state: (self.can_team_attack(state) and self.can_cling(state)) or (self.has_squitter(state) and (
+                    (self.has_both_kongs(state) and self.can_cling(state)) or self.can_team_attack(state))
+                    ),
             LocationName.hornet_hole_banana_coin_2:
                 self.true,
             LocationName.hornet_hole_green_balloon_1:
@@ -4115,15 +4122,25 @@ class DKC2ExpertRules(DKC2Rules):
             LocationName.hornet_hole_banana_coin_3:
                 self.true,
             LocationName.hornet_hole_banana_bunch_3:
-                lambda state: self.can_team_attack(state) and self.has_squitter(state) and (self.can_cling(state) or self.has_both_kongs(state)),
+                lambda state: self.has_squitter(state) and (
+                    (self.has_both_kongs(state) and self.can_cling(state)) or self.can_team_attack(state)
+                    ),
             LocationName.hornet_hole_banana_coin_4:
-                lambda state: self.can_team_attack(state) and self.has_squitter(state) and (self.can_cling(state) or self.has_both_kongs(state)),
+                lambda state: self.has_squitter(state) and (
+                    (self.has_both_kongs(state) and self.can_cling(state)) or self.can_team_attack(state)
+                    ),
             LocationName.hornet_hole_banana_bunch_4:
-                lambda state: self.can_team_attack(state) and self.has_squitter(state) and (self.can_cling(state) or self.has_both_kongs(state)),
+                lambda state: self.has_squitter(state) and (
+                    (self.has_both_kongs(state) and self.can_cling(state)) or self.can_team_attack(state)
+                    ),
             LocationName.hornet_hole_banana_bunch_5:
-                lambda state: self.can_team_attack(state) or self.has_both_kongs(state),
+                lambda state: self.can_team_attack(state) or self.has_both_kongs(state) or (self.has_squitter(state) and (
+                    (self.has_both_kongs(state) and self.can_cling(state)))
+                    ),
             LocationName.hornet_hole_red_balloon_1:
-                lambda state: self.can_team_attack(state) and self.has_squitter(state) and (self.can_cling(state) or self.has_both_kongs(state)),
+                lambda state: self.has_squitter(state) and (
+                    (self.has_both_kongs(state) and self.can_cling(state)) or self.can_team_attack(state)
+                    ),
 
             LocationName.target_terror_banana_bunch_1:
                 lambda state: self.has_kannons(state) and self.has_skull_kart(state),
@@ -4135,19 +4152,19 @@ class DKC2ExpertRules(DKC2Rules):
             LocationName.bramble_scramble_banana_bunch_1:
                 self.true,
             LocationName.bramble_scramble_banana_bunch_2:
-                 lambda state: self.can_carry(state) and self.has_both_kongs(state) and self.can_climb(state),
+                self.has_both_kongs,
             LocationName.bramble_scramble_banana_coin_1:
                 lambda state: self.can_climb(state) and self.has_kannons(state) and ((
                     self.can_team_attack(state) and self.has_invincibility(state)
                     ) or (
-                    self.can_hover(state) and self.has_both_kongs(state)
+                    (self.can_hover(state) or self.can_cartwheel(state)) and self.has_both_kongs(state)
                     )
                 ),
             LocationName.bramble_scramble_banana_coin_2:
                 lambda state: self.can_climb(state) and self.has_squawks(state) and ((
                     self.can_team_attack(state) and self.has_invincibility(state)
                     ) or (
-                    self.can_hover(state) and self.has_kannons(state) and self.has_both_kongs(state)
+                    (self.can_hover(state) or self.can_cartwheel(state)) and self.has_kannons(state) and self.has_both_kongs(state)
                     )
                 ),
             LocationName.bramble_scramble_banana_coin_3:
@@ -4641,23 +4658,23 @@ class DKC2ExpertRules(DKC2Rules):
                 self.has_controllable_barrels,
             LocationName.klobber_karnage_banana_bunch_5:
                 lambda state: self.has_controllable_barrels(state) and 
-                    (self.has_both_kongs(state) or (self.can_use_dixie_barrels (state) and self.can_use_diddy_barrels(state))
+                    (self.has_both_kongs(state) or (self.can_use_dixie_barrels(state) and self.can_use_diddy_barrels(state))
                 ),
             LocationName.klobber_karnage_banana_bunch_6:
                 lambda state: self.has_controllable_barrels(state) and 
-                    (self.has_both_kongs(state) or (self.can_use_dixie_barrels (state) and self.can_use_diddy_barrels(state))
+                    (self.has_both_kongs(state) or (self.can_use_dixie_barrels(state) and self.can_use_diddy_barrels(state))
                 ),
             LocationName.klobber_karnage_banana_bunch_7:
                 lambda state: self.has_controllable_barrels(state) and 
-                    (self.has_both_kongs(state) or (self.can_use_dixie_barrels (state) and self.can_use_diddy_barrels(state))
+                    (self.has_both_kongs(state) or (self.can_use_dixie_barrels(state) and self.can_use_diddy_barrels(state))
                 ),
             LocationName.klobber_karnage_banana_coin_4:
                 lambda state: self.has_controllable_barrels(state) and 
-                    (self.has_both_kongs(state) or (self.can_use_dixie_barrels (state) and self.can_use_diddy_barrels(state))
+                    (self.has_both_kongs(state) or (self.can_use_dixie_barrels(state) and self.can_use_diddy_barrels(state))
                 ),
             LocationName.klobber_karnage_red_balloon:
                 lambda state: self.has_controllable_barrels(state) and (self.can_cartwheel(state) or self.can_hover(state)) and
-                    (self.has_both_kongs(state) or (self.can_use_dixie_barrels (state) and self.can_use_diddy_barrels(state))
+                    (self.has_both_kongs(state) or (self.can_use_dixie_barrels(state) and self.can_use_diddy_barrels(state))
                 ),
 
             LocationName.fiery_furnace_banana_bunch_1:
@@ -4682,64 +4699,55 @@ class DKC2ExpertRules(DKC2Rules):
                         )
                     ),
             LocationName.animal_antics_banana_bunch_2:
-                lambda state: self.can_swim(state) and
-                        self.has_squitter and self.has_enguarde(state) and (
+                lambda state: self.can_swim(state) and self.has_enguarde(state) and (
                         self.has_rambi(state) or (
                             self.can_hover(state) and self.can_team_attack(state)
                         )
                     ),
             LocationName.animal_antics_banana_coin_1:
-                lambda state: self.can_swim(state) and 
-                        self.has_squitter and self.has_enguarde(state) and (
+                lambda state: self.can_swim(state) and self.has_enguarde(state) and (
                         self.has_rambi(state) or (
                             self.can_hover(state) and self.can_team_attack(state)
                         )
                     ),
             LocationName.animal_antics_banana_coin_2:
-                lambda state: self.can_swim(state) and self.has_kannons(state) and
-                        self.has_squitter and self.has_enguarde(state) and (
+                lambda state: self.can_swim(state) and self.has_kannons(state) and self.has_enguarde(state) and (
                         self.has_rambi(state) or (
                             self.can_hover(state) and self.can_team_attack(state)
                         )
                     ),
             LocationName.animal_antics_banana_bunch_3:
-                lambda state: self.can_swim(state) and self.has_kannons(state) and
-                        self.has_squitter and self.has_enguarde(state) and (
+                lambda state: self.can_swim(state) and self.has_kannons(state) and self.has_enguarde(state) and (
                         self.has_rambi(state) or (
                             self.can_hover(state) and self.can_team_attack(state)
                         )
                     ),
             LocationName.animal_antics_banana_bunch_4:
-                lambda state: self.can_swim(state) and self.has_kannons(state) and
-                        self.has_squitter and self.has_enguarde(state) and (
+                lambda state: self.can_swim(state) and self.has_kannons(state) and self.has_enguarde(state) and (
                         self.has_rambi(state) or (
                             self.can_hover(state) and self.can_team_attack(state)
                         )
                     ),
             LocationName.animal_antics_banana_coin_3:
-                lambda state: self.can_swim(state) and self.has_kannons(state) and
-                        self.has_squitter and self.has_enguarde(state) and (
+                lambda state: self.can_swim(state) and self.has_kannons(state) and self.has_enguarde(state) and (
                         self.has_rambi(state) or (
                             self.can_hover(state) and self.can_team_attack(state)
                         )
                     ),
             LocationName.animal_antics_banana_coin_4:
-                lambda state: self.can_swim(state) and self.has_kannons(state) and
-                        self.has_squitter and self.has_enguarde(state) and (
+                lambda state: self.can_swim(state) and self.has_kannons(state) and self.has_enguarde(state) and (
                         self.has_rambi(state) or (
                             self.can_hover(state) and self.can_team_attack(state)
                         )
                     ),
             LocationName.animal_antics_red_balloon:
-                lambda state: self.can_swim(state) and self.has_kannons(state) and
-                        self.has_squitter and self.has_enguarde(state) and (
+                lambda state: self.can_swim(state) and self.has_kannons(state) and self.has_enguarde(state) and (
                         self.has_rambi(state) or (
                             self.can_hover(state) and self.can_team_attack(state)
                         )
                     ),
             LocationName.animal_antics_banana_coin_5:
-                lambda state: self.can_swim(state) and self.has_kannons(state) and
-                        self.has_squitter and self.has_enguarde(state) and (
+                lambda state: self.can_swim(state) and self.has_kannons(state) and self.has_enguarde(state) and (
                         self.has_rambi(state) or (
                             self.can_hover(state) and self.can_team_attack(state)
                         )

--- a/worlds/dkc2/Rules.py
+++ b/worlds/dkc2/Rules.py
@@ -3123,6 +3123,7 @@ class DKC2ExpertRules(DKC2Rules):
             LocationName.gangplank_galley_dk_coin:
                 lambda state: self.can_cartwheel(state) and (
                     self.can_cling(state) or self.can_hover(state)
+                    ) or (self.can_team_attack(state) and self.can_cling(state)
                 ),
             LocationName.gangplank_galley_bonus_1:
                 self.can_carry,

--- a/worlds/dkc2/Rules.py
+++ b/worlds/dkc2/Rules.py
@@ -1387,7 +1387,7 @@ class DKC2StrictRules(DKC2Rules):
                     self.has_both_kongs(state),
             LocationName.castle_crush_banana_bunch_5:
                 lambda state: self.has_rambi(state) and self.can_carry(state) and 
-                    self.has_both_kongs(state) and self.can_cartwheel(state),
+                    self.has_both_kongs(state) and self.can_cartwheel(state) and self.has_squawks(state),
             LocationName.castle_crush_banana_coin_3:
                 lambda state: self.has_rambi(state) and self.can_carry(state) and 
                     self.has_both_kongs(state) and self.can_cartwheel(state),
@@ -2661,9 +2661,9 @@ class DKC2LooseRules(DKC2Rules):
                     self.can_climb(state),
 
             LocationName.rambi_rumble_banana_coin_1:
-                self.can_hover,
+                self.true,
             LocationName.rambi_rumble_banana_bunch_1:
-                self.can_hover,
+                lambda state: self.can_hover(state) or self.can_cartwheel(state),
             LocationName.rambi_rumble_banana_bunch_2:
                 lambda state: self.can_cling(state) and self.has_kannons(state),
             LocationName.rambi_rumble_banana_coin_2:
@@ -2763,13 +2763,13 @@ class DKC2LooseRules(DKC2Rules):
                     self.can_carry(state),
 
             LocationName.arctic_abyss_banana_coin_1:
-                lambda state: self.can_team_attack(state) and (self.can_cartwheel(state) or self.can_hover(state)),
+                lambda state: self.can_hover(state) or (self.has_diddy(state) and self.can_cartwheel(state)),
             LocationName.arctic_abyss_banana_bunch_1:
-                lambda state: self.can_team_attack(state) and (self.can_cartwheel(state) or self.can_hover(state)),
+                lambda state: self.can_hover(state) or (self.has_diddy(state) and self.can_cartwheel(state)),
             LocationName.arctic_abyss_banana_bunch_2:
-                lambda state: self.can_team_attack(state) and (self.can_cartwheel(state) or self.can_hover(state)),
+                lambda state: self.can_hover(state) or (self.has_diddy(state) and self.can_cartwheel(state)),
             LocationName.arctic_abyss_banana_bunch_3:
-                lambda state: self.can_team_attack(state) and (self.can_cartwheel(state) or self.can_hover(state)),
+                lambda state: self.can_hover(state) or (self.has_diddy(state) and self.can_cartwheel(state)),
             LocationName.arctic_abyss_banana_bunch_4:
                 self.can_swim,
             LocationName.arctic_abyss_banana_coin_2:
@@ -2812,17 +2812,13 @@ class DKC2LooseRules(DKC2Rules):
                     self.has_squawks(state),
 
             LocationName.castle_crush_banana_coin_1:
-                lambda state: self.can_carry(state) and 
-                    self.has_both_kongs(state),
+                self.has_both_kongs,
             LocationName.castle_crush_banana_bunch_1:
-                lambda state: self.can_carry(state) and 
-                    self.has_both_kongs(state),
+                self.has_both_kongs,
             LocationName.castle_crush_banana_bunch_2:
-                lambda state: self.can_carry(state) and 
-                    self.has_both_kongs(state),
+                self.has_both_kongs,
             LocationName.castle_crush_banana_coin_2:
-                lambda state: self.can_carry(state) and 
-                    self.has_both_kongs(state),
+                self.has_both_kongs,
             LocationName.castle_crush_banana_bunch_3:
                 lambda state: self.has_rambi(state) and self.can_carry(state) and 
                     self.has_both_kongs(state),
@@ -3012,12 +3008,9 @@ class DKC2LooseRules(DKC2Rules):
                 lambda state: self.can_cartwheel(state) and self.can_use_diddy_barrels(state) and 
                     self.has_controllable_barrels(state),
             LocationName.klobber_karnage_banana_bunch_4:
-                lambda state: self.can_cartwheel(state) and self.can_use_diddy_barrels(state) and 
-                    self.can_use_dixie_barrels(state) and self.has_controllable_barrels(state),
+                lambda state: (self.has_diddy(state) and self.can_cartwheel(state) or self.can_hover(state)),
             LocationName.klobber_karnage_banana_bunch_5:
-                lambda state: self.can_cartwheel(state) and self.can_use_diddy_barrels(state) and 
-                    self.can_use_dixie_barrels(state) and self.has_controllable_barrels(state) and 
-                    self.has_kannons(state),
+                lambda state: (self.has_diddy(state) and self.can_cartwheel(state) or self.can_hover(state) and self.has_kannons(state)),
             LocationName.klobber_karnage_banana_bunch_6:
                 lambda state: self.can_cartwheel(state) and self.can_use_diddy_barrels(state) and 
                     self.can_use_dixie_barrels(state) and self.has_controllable_barrels(state) and 

--- a/worlds/dkc2/Rules.py
+++ b/worlds/dkc2/Rules.py
@@ -2812,13 +2812,13 @@ class DKC2LooseRules(DKC2Rules):
                     self.has_squawks(state),
 
             LocationName.castle_crush_banana_coin_1:
-                self.has_both_kongs,
+                self.true,
             LocationName.castle_crush_banana_bunch_1:
-                self.has_both_kongs,
+                self.true,
             LocationName.castle_crush_banana_bunch_2:
-                self.has_both_kongs,
+                self.true,
             LocationName.castle_crush_banana_coin_2:
-                self.has_both_kongs,
+                self.true,
             LocationName.castle_crush_banana_bunch_3:
                 lambda state: self.has_rambi(state) and self.can_carry(state) and 
                     self.has_both_kongs(state),

--- a/worlds/dkc2/Rules.py
+++ b/worlds/dkc2/Rules.py
@@ -1899,14 +1899,14 @@ class DKC2LooseRules(DKC2Rules):
                 lambda state: self.has_kannons(state) and self.has_skull_kart(state),
 
             LocationName.bramble_scramble_clear:
-                lambda state: self.can_hover(state) and self.can_climb(state) and self.has_squawks(state),
+                lambda state: self.can_climb(state) and self.has_squawks(state),
             LocationName.bramble_scramble_kong:
-                lambda state: self.can_hover(state) and self.can_climb(state) and self.has_squawks(state) and self.has_kannons(state),
+                lambda state: self.can_climb(state) and self.has_squawks(state) and self.has_kannons(state),
             LocationName.bramble_scramble_dk_coin:
-                lambda state: self.can_hover(state) and self.can_cartwheel(state) and self.can_climb(state) and 
+                lambda state: self.can_cartwheel(state) and self.can_climb(state) and 
                     self.has_squitter(state) and self.has_squawks(state) and self.has_kannons(state),
             LocationName.bramble_scramble_bonus_1:
-                lambda state: self.can_hover(state) and self.can_climb(state) and self.can_team_attack(state) and
+                lambda state: self.can_climb(state) and self.can_team_attack(state) and
                     self.has_invincibility(state) and self.has_kannons(state) and self.has_squawks(state),
 
             LocationName.rickety_race_clear:

--- a/worlds/dkc2/Rules.py
+++ b/worlds/dkc2/Rules.py
@@ -293,16 +293,16 @@ class DKC2StrictRules(DKC2Rules):
                 lambda state: self.has_squitter(state) and self.has_kannons(state),
 
             LocationName.kannons_klaim_clear:
-                lambda state: self.can_carry(state) and self.has_kannons(state) and self.can_hover(state),
+                lambda state: self.can_carry(state) and self.has_kannons(state),
             LocationName.kannons_klaim_kong:
-                lambda state: self.can_carry(state) and self.has_kannons(state) and self.can_hover(state),
+                lambda state: self.can_carry(state) and self.has_kannons(state),
             LocationName.kannons_klaim_dk_coin:
                 lambda state: self.can_hover(state),
             LocationName.kannons_klaim_bonus_1:
                 lambda state: self.can_use_diddy_barrels(state) and self.can_use_dixie_barrels(state) and
                     self.can_hover(state),
             LocationName.kannons_klaim_bonus_2:
-                lambda state: self.can_carry(state) and self.can_team_attack(state) and self.has_kannons(state) and self.can_hover(state),
+                lambda state: self.can_carry(state) and self.can_team_attack(state) and self.has_kannons(state),
             LocationName.kannons_klaim_bonus_3:
                 lambda state: self.can_carry(state) and self.has_kannons(state) and self.can_hover(state),
 


### PR DESCRIPTION
strict:
eliminados algunos hover de kannons klaim
añadido squakws a 1 check de castle crush

loose:
fixes de lx5 (rambi rumble, castle crush, arctic abyss, klobber karnage)
eliminados algunos hover de bramble scramble

expert:
fixes de vash

genera bien en las 3 logicas