### PR TITLE
mas fixes (sesion 22 feb 2025)

### DIFF
--- a/worlds/dkc2/Rules.py
+++ b/worlds/dkc2/Rules.py
@@ -541,7 +541,7 @@ class DKC2StrictRules(DKC2Rules):
             LocationName.gusty_glade_dk_coin:
                 lambda state: self.can_cling(state) and self.has_kannons(state) and self.can_hover(state),
             LocationName.gusty_glade_bonus_1:
-                lambda state: self.can_cling(state) and self.can_team_attack(state),
+                lambda state: self.can_team_attack(state) and (self.can_cling(state) or self.has_rattly(state)),
             LocationName.gusty_glade_bonus_2:
                 lambda state: self.can_cling(state) and self.can_carry(state) and self.has_kannons(state),
 
@@ -1998,7 +1998,7 @@ class DKC2LooseRules(DKC2Rules):
             LocationName.gusty_glade_dk_coin:
                 lambda state: self.can_cling(state) and self.has_kannons(state) and self.can_hover(state),
             LocationName.gusty_glade_bonus_1:
-                lambda state: self.can_cling(state) and self.can_team_attack(state),
+                lambda state: self.can_team_attack(state) and (self.can_cling(state) or self.has_rattly(state)),
             LocationName.gusty_glade_bonus_2:
                 lambda state: self.can_cling(state) and self.can_carry(state) and self.has_kannons(state),
 
@@ -3460,7 +3460,7 @@ class DKC2ExpertRules(DKC2Rules):
             LocationName.gusty_glade_dk_coin:
                 lambda state: self.can_cling(state) and self.has_kannons(state),
             LocationName.gusty_glade_bonus_1:
-                lambda state: self.can_cling(state) and self.can_team_attack(state),
+                lambda state: self.can_team_attack(state) and (self.can_cling(state) or self.has_rattly(state)),
             LocationName.gusty_glade_bonus_2:
                 lambda state: self.can_cling(state) and self.can_carry(state) and self.has_kannons(state),
 

--- a/worlds/dkc2/Rules.py
+++ b/worlds/dkc2/Rules.py
@@ -3241,17 +3241,25 @@ class DKC2ExpertRules(DKC2Rules):
                 lambda state: self.can_cling(state) and self.can_carry(state),
 
             LocationName.barrel_bayou_clear:
-                lambda state: self.has_controllable_barrels(state) and self.has_kannons(state),
+                lambda state: (self.has_controllable_barrels(state) or (self.can_hover(state) and self.can_cartwheel(state) and self.has_rambi(state))) 
+                    and (self.has_kannons(state) or (self.can_hover(state) and self.can_team_attack(state))
+                ),
             LocationName.barrel_bayou_kong:
                 lambda state: self.has_controllable_barrels(state) and self.has_kannons(state) and (
                     self.can_team_attack(state) or self.can_cartwheel(state)
                 ),
             LocationName.barrel_bayou_dk_coin:
-                lambda state: self.has_controllable_barrels(state) and self.has_rambi(state),
+                lambda state: self.has_rambi(state) and (
+                    self.has_controllable_barrels(state) or (self.can_hover(state) and self.can_cartwheel(state))
+                ),
             LocationName.barrel_bayou_bonus_1:
-                lambda state: self.has_controllable_barrels(state) and self.can_carry(state),
+                lambda state: self.can_carry(state) and (
+                    self.has_controllable_barrels(state) or (self.can_hover(state) and self.can_cartwheel(state) and self.has_rambi(state))
+                ),
             LocationName.barrel_bayou_bonus_2:
-                lambda state: self.has_controllable_barrels(state) and self.has_kannons(state),
+                lambda state: self.has_controllable_barrels(state) and 
+                    (self.has_kannons(state) or (self.can_hover(state) and self.can_team_attack(state))
+                ),
 
             LocationName.glimmers_galleon_clear:
                 self.can_swim,
@@ -3970,17 +3978,26 @@ class DKC2ExpertRules(DKC2Rules):
             LocationName.barrel_bayou_banana_bunch_1:
                 lambda state: self.can_team_attack(state) or self.has_both_kongs(state),
             LocationName.barrel_bayou_banana_coin_1:
-                self.has_controllable_barrels,
+                lambda state: self.has_controllable_barrels(state) or 
+                    (self.can_hover(state) and self.can_cartwheel(state) and self.has_rambi(state)
+                ),
             LocationName.barrel_bayou_banana_bunch_2:
-                self.has_controllable_barrels,
+                lambda state: self.has_controllable_barrels(state) or 
+                    (self.can_hover(state) and self.can_cartwheel(state) and self.has_rambi(state)
+                ),
             LocationName.barrel_bayou_green_balloon:
-                lambda state: self.has_controllable_barrels(state) and self.can_carry(state) and (
+                lambda state: (self.has_controllable_barrels(state) or (self.can_hover(state) and self.can_cartwheel(state) and self.has_rambi(state)))
+                    and self.can_carry(state) and (
                     self.has_kannons(state) or self.can_hover(state)
-                    ),
+                ),
             LocationName.barrel_bayou_banana_coin_2:
-                lambda state: self.has_controllable_barrels(state) and self.has_kannons(state),
+                lambda state: (self.has_controllable_barrels(state) or (self.can_hover(state) and self.can_cartwheel(state) and self.has_rambi(state))) 
+                    and (self.has_kannons(state) or (self.can_hover(state) and self.can_team_attack(state))
+                ),
             LocationName.barrel_bayou_banana_bunch_3:
-                lambda state: self.has_controllable_barrels(state) and self.has_kannons(state),
+                lambda state: (self.has_controllable_barrels(state) or (self.can_hover(state) and self.can_cartwheel(state) and self.has_rambi(state))) 
+                    and (self.has_kannons(state) or (self.can_hover(state) and self.can_team_attack(state))
+                ),
 
             LocationName.glimmers_galleon_banana_coin_1:
                 self.can_swim,

--- a/worlds/dkc2/Rules.py
+++ b/worlds/dkc2/Rules.py
@@ -352,19 +352,15 @@ class DKC2StrictRules(DKC2Rules):
                 lambda state: self.can_cling(state) and self.can_carry(state) and self.has_both_kongs(state),
 
             LocationName.barrel_bayou_clear:
-                lambda state: self.has_controllable_barrels(state) and self.has_rambi(state) and
-                    self.has_kannons(state),
+                lambda state: self.has_controllable_barrels(state) and self.has_kannons(state),
             LocationName.barrel_bayou_kong:
-                lambda state: self.has_controllable_barrels(state) and self.has_rambi(state) and
-                    self.has_kannons(state) and self.can_cartwheel(state),
+                lambda state: self.has_controllable_barrels(state) and self.has_kannons(state) and self.can_cartwheel(state),
             LocationName.barrel_bayou_dk_coin:
                 lambda state: self.has_controllable_barrels(state) and self.has_rambi(state),
             LocationName.barrel_bayou_bonus_1:
-                lambda state: self.has_controllable_barrels(state) and self.has_rambi(state) and
-                    self.can_carry(state),
+                lambda state: self.has_controllable_barrels(state) and self.can_carry(state),
             LocationName.barrel_bayou_bonus_2:
-                lambda state: self.has_controllable_barrels(state) and self.has_rambi(state) and
-                    self.has_kannons(state) and self.can_team_attack(state),
+                lambda state: self.has_controllable_barrels(state) and self.has_kannons(state) and self.can_team_attack(state),
 
             LocationName.glimmers_galleon_clear:
                 lambda state: self.can_swim(state) and self.has_glimmer(state),
@@ -867,7 +863,7 @@ class DKC2StrictRules(DKC2Rules):
             LocationName.hot_head_hop_banana_bunch_1:
                 self.can_carry,
             LocationName.hot_head_hop_banana_coin_2:
-                self.has_squitter,
+                lambda state: self.has_squitter(state) or self.can_team_attack(state),
             LocationName.hot_head_hop_banana_bunch_2:
                 self.has_squitter,
             LocationName.hot_head_hop_banana_bunch_3:
@@ -992,14 +988,13 @@ class DKC2StrictRules(DKC2Rules):
             LocationName.barrel_bayou_banana_coin_1:
                 lambda state: self.has_controllable_barrels(state) and self.has_rambi(state),
             LocationName.barrel_bayou_banana_bunch_2:
-                lambda state: self.has_controllable_barrels(state) and self.has_rambi(state),
+                self.has_controllable_barrels,
             LocationName.barrel_bayou_green_balloon:
-                lambda state: self.has_controllable_barrels(state) and self.has_rambi(state) and self.can_carry(state) and self.has_kannons(state),
+                lambda state: self.has_controllable_barrels(state) and self.can_carry(state) and self.has_kannons(state),
             LocationName.barrel_bayou_banana_coin_2:
-                lambda state: self.has_controllable_barrels(state) and self.has_rambi(state) and self.has_kannons(state),
+                lambda state: self.has_controllable_barrels(state) and self.has_kannons(state),
             LocationName.barrel_bayou_banana_bunch_3:
-                lambda state: self.has_controllable_barrels(state) and self.has_rambi(state) and 
-                    self.has_kannons(state) and self.can_team_attack(state),
+                lambda state: self.has_controllable_barrels(state) and self.has_kannons(state) and self.can_team_attack(state),
 
             LocationName.glimmers_galleon_banana_coin_1:
                 lambda state: self.can_swim(state) and self.has_glimmer(state),


### PR DESCRIPTION
general:
gusty glade bonus 1 ahora tiene rattly como opcion en las 3 logicas

strict:
eliminado rambi de varios checks en barrel bayou
añadido team attack a una moneda en hot head hop

expert:
vash.mp4 (barrel bayou)
