### PR TITLE
DKC2 - Fix color adjust, Allow zero extra Lost World Rocks

### DIFF
--- a/worlds/dkc2/Aesthetics.py
+++ b/worlds/dkc2/Aesthetics.py
@@ -212,7 +212,9 @@ dixie_palettes = {
 # Code taken from https://stackoverflow.com/a/69083087
 def adjust_color(r, g, b, factor):
     h, l, s = rgb_to_hls(r / 255.0, g / 255.0, b / 255.0)
+    # Scale both luminescence and saturation but don't adjust hue
     l = max(min(l * factor, 1.0), 0.0)
+    s = max(min(s * factor * 2.0/3.0, 1.0), 0.0)
     r, g, b = hls_to_rgb(h, l, s)
     return int(r * 255), int(g * 255), int(b * 255)
     

--- a/worlds/dkc2/Options.py
+++ b/worlds/dkc2/Options.py
@@ -84,7 +84,7 @@ class ExtraLostWorldRocks(Range):
     How many additional Lost World Rocks can be found in the multiworld
     """
     display_name = "Extra Lost World Rocks"
-    range_start = 1
+    range_start = 0
     range_end = 5
     default = 3
 


### PR DESCRIPTION
## What is this fixing or adding?
This corrects the colour adjustment done when specifying the `player_palette_filters` options.  The original code only adjusted the luminescence of the colour without adjusting the saturation, making colours appear way too saturated after being darkened or lightened.

In addition, changed the options for DKC2 to allow generating worlds with only the exact number of Lost World Rocks needed for goal (that is, allowed setting zero `extra_lost_world_rocks`).  This does not seem to cause any issues with the logic in my testing.

## How was this tested?
- Generating multiple seeds with various palette filter options and verifying that the colours looked correctly darkened or lightened.
- Generating multiple seeds with zero `extra_lost_world_rocks` and verifying that generation was successful, the logic was correct, and the seeds were completeable.

## If this makes graphical changes, please attach screenshots.
Somehow I didn't think about how this made graphical changes and thought screenshots weren't required... I'll upload them shortly!
