### PR TITLE
Logic fix: DP2 Secret Exit

### DIFF
--- a/worlds/waffles/Rules.py
+++ b/worlds/waffles/Rules.py
@@ -397,9 +397,7 @@ class WaffleBasicRules(WaffleRules):
             f"{Regions.donut_plains_2_region} -> {Locations.donut_plains_2_exit_1}": 
                 True_(),
             f"{Regions.donut_plains_2_region} -> {Locations.donut_plains_2_exit_2}": 
-                CanYoshiCarry | (CanClimb & (
-                    (CanCarry & CanBreakTurnBlocks) | HasYoshi)
-                ),
+                CanYoshiCarry | (CanClimb & CanCarry & (CanBreakTurnBlocks | HasYoshi)),
             f"{Regions.donut_plains_3_region} -> {Locations.donut_plains_3_exit_1}": 
                 True_(),
             f"{Regions.donut_plains_4_region} -> {Locations.donut_plains_4_exit_1}": 


### PR DESCRIPTION
When Carryless Exits are off, the keyhole exits require Carry, as activating the keyhole requires carrying a key. This fixes Donut Plains 2's secret exit's logic. 

## What is this fixing?
A logic error that makes Donut Plains 2's secret exit inaccessable while Carryless Exits is off.

## How was this tested?
Playing Waffles normally with Level Shuffle. Two generations I've tested both placed DP2 to the Donut Ghost House chokepoint, with no way to get Carry.
